### PR TITLE
Replaced deprecated 'File.exists?' with 'File.exist?'

### DIFF
--- a/lib/http_spec/clients/raddocs_proxy.rb
+++ b/lib/http_spec/clients/raddocs_proxy.rb
@@ -48,7 +48,7 @@ module HTTPSpec
       end
 
       def load_or_new(klass, filepath, *args)
-        if File.exists?(filepath)
+        if File.exist?(filepath)
           File.open(filepath, "r") { |file| klass.load(file) }
         else
           klass.new(*args)

--- a/lib/http_spec/clients/vcr_proxy.rb
+++ b/lib/http_spec/clients/vcr_proxy.rb
@@ -26,7 +26,7 @@ module HTTPSpec
         end
 
         def new?
-          @new ||= !File.exists?(@filepath)
+          @new ||= !File.exist?(@filepath)
         end
 
         def record(request, response)
@@ -47,7 +47,7 @@ module HTTPSpec
 
         def cache
           @cache ||=
-            if File.exists?(@filepath)
+            if File.exist?(@filepath)
               File.open(@filepath, "r+") do |file|
                 Marshal.load(file)
               end


### PR DESCRIPTION
## Description
Replaced deprecated `File.exists?` with `File.exist?`

## Motivation
`File.exists?` was removed in Ruby 3.2, as it had been deprecated since Ruby 2.1 in favor of `File.exist?`.

See [Ruby 3.2 release notes](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/) for more details.